### PR TITLE
Fix mobile ToC overlay: make ToC non-blocking and static on small screens

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -94,7 +94,8 @@ h2, h3, h4 { font-weight: 600; }
 /* Mobile layout */
 @media (max-width: 960px) {
   .layout { grid-template-columns: 1fr; gap: 16px; }
-  .toc { position: fixed; top: 64px; right: 16px; left: 16px; height: auto; max-height: 60dvh; display: none; z-index: 1001; }
+  /* Make ToC a non-overlay block on mobile */
+  .toc { position: static; top: auto; right: auto; left: auto; height: auto; max-height: none; display: none; z-index: auto; }
   .toc.open { display: block; }
 }
 


### PR DESCRIPTION
This PR fixes the issue where the Table of Contents covers the page and intercepts interactions on mobile.

Changes:
- On small screens (<=960px), make `#toc` a non-overlay block (`position: static`, no z-index) and only toggle visibility with `.open`.
- Keeps desktop behavior unchanged: sticky sidebar with scrollable contents.

Why:
- Prevents the ToC from covering page content and blocking taps.

Tested:
- Desktop: sticky sidebar works, active link highlight and intersection observer OK.
- Mobile: ToC opens as a block above content and no longer blocks page interactions.
